### PR TITLE
adds rules for notification logs

### DIFF
--- a/filter-50-notification.conf
+++ b/filter-50-notification.conf
@@ -27,17 +27,17 @@ filter {
         add_tag => "icinga_notificationtype"
         tag_on_failure => ["_grokparsefailure","icinga_notificationtype_failed"]
         add_field => {
-          "[icinga][eventtype]" => "notificationtypeevaluation"
+          "[icinga][eventtype]" => "notification_typeevaluation"
         }
       }
-    } else if [message] =~ /^Attempting to send  notifications for notification object/ {
+    } else if [message] =~ /^Attempting to send( |  )notifications for notification object/ {
       grok {
-        match => ["message","Attempting to send  notifications for notification object '%{DATA:[icinga][object]}'."]
+        match => ["message","Attempting to send%{SPACE}notifications for notification object '%{DATA:[icinga][object]}'."]
         id => "icinga_notificationattempt"
         add_tag => "icinga_notificationattempt"
         tag_on_failure => ["_grokparsefailure","icinga_notificationattempt_failed"]
         add_field => {
-          "[icinga][eventtype]" => "notificationattempt"
+          "[icinga][eventtype]" => "notification_attempt"
         }
       }
     } else if [message] =~ /^State ('.+'|'.+',) StateFilter: .+/ {
@@ -47,7 +47,7 @@ filter {
         add_tag => "icinga_notificationstate"
         tag_on_failure => ["_grokparsefailure","icinga_notificationstate_failed"]
         add_field => {
-          "[icinga][eventtype]" => "notificationstateevaluation"
+          "[icinga][eventtype]" => "notification_state_evaluation"
         }
       }
     } else if [message] =~ /^User '.+' notification '.+', Type '.+', TypeFilter: .+/ {
@@ -57,7 +57,7 @@ filter {
         add_tag => "icinga_notificationusertypeevaluation"
         tag_on_failure => ["_grokparsefailure","icinga_notificationusertypeevaluation_failed"]
         add_field => {
-          "[icinga][eventtype]" => "notificationusertypeevaluation"
+          "[icinga][eventtype]" => "notification_user_type_evaluation"
         }
       }
     } else if [message] =~ /^User '.+' notification '.+', State '.+', StateFilter: .+/ {
@@ -67,9 +67,10 @@ filter {
         add_tag => "icinga_notificationuserstateevaluation"
         tag_on_failure => ["_grokparsefailure","icinga_notificationuserstateevaluation_failed"]
         add_field => {
-          "[icinga][eventtype]" => "notificationuserstateevaluation"
+          "[icinga][eventtype]" => "notification_user_state_evaluation"
         }
       }
     }
   }
 }
+


### PR DESCRIPTION
Just realized that i didn't pay attention to the naming scheme, added "_" to separate the eventtype, like it should be and because of this: https://github.com/Icinga/icinga2/pull/7192 as soon as that gets accepted, we will have to expand on _notification_attempt_ , so i dealt with that upfront. Just in case someone doesn't update their icinga2.

refers to #15